### PR TITLE
Code Review & Refactoring for Posts Generator

### DIFF
--- a/Tests/Integration/FilterWPQueryTest.php
+++ b/Tests/Integration/FilterWPQueryTest.php
@@ -28,7 +28,7 @@ class FilterWPQueryTest extends IntegrationTestCase
 		//Make sure addFilter() had the right effect --  it was added with priority 10
 		$this->assertEquals(
 			FilterWPQuery::getFilterPriority(),
-			has_filter('posts_pre_query', [FilterWPQuery::class, 'callback'])
+			has_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'])
 		);
 	}
 
@@ -44,7 +44,7 @@ class FilterWPQueryTest extends IntegrationTestCase
 		//Remove and test return type
 		$this->assertTrue(FilterWPQuery::removeFilter());
 		//Make sure removeFilter() had the right effect -- the filter was removed
-		$this->assertFalse(has_filter('posts_pre_query', [FilterWPQuery::class, 'callback']));
+		$this->assertFalse(has_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery']));
 	}
 
 
@@ -62,7 +62,7 @@ class FilterWPQueryTest extends IntegrationTestCase
 		//Add filter
 		FilterWPQuery::addFilter();
 		//Test that the filter SHOULD not do anything
-		$this->assertFalse(FilterWPQuery::shouldFilter());
+		$this->assertFalse(FilterWPQuery::shouldFilter([]));
 		//Query for all posts -- should only be one post, the one we just created.
 		$query = new \WP_Query(['post_type' => 'post']);
 		$this->assertFalse(empty($query->posts));

--- a/Tests/Integration/FilterWPQueryTest.php
+++ b/Tests/Integration/FilterWPQueryTest.php
@@ -52,7 +52,7 @@ class FilterWPQueryTest extends IntegrationTestCase
 	 * Test that by default this class does not do anything by default
 	 *
 	 * @covers FilterWPQuery::shouldFilter()
-	 * @covers FilterWPQuery::callback()
+	 * @covers FilterWPQuery::filterPreQuery()
 	 */
 	public function testNotFilteringByDefault()
 	{
@@ -115,7 +115,7 @@ class FilterWPQueryTest extends IntegrationTestCase
 	public function testGetPostsArePostsShouldFilter()
 	{
 		//Get the mock posts
-		$results = AlwaysFilterWPQuery::callback(null);
+		$results = AlwaysFilterWPQuery::filterPreQuery(null);
 		$this->assertTrue(is_array($results));
 		$this->assertFalse(empty($results));
 		$expected = AlwaysFilterWPQuery::getPosts();

--- a/Tests/Integration/FilterWPQueryTest.php
+++ b/Tests/Integration/FilterWPQueryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace CalderaLearn\RestSearch\Tests\Integration;
 
 use CalderaLearn\RestSearch\FilterWPQuery;
@@ -15,7 +14,6 @@ use CalderaLearn\RestSearch\Tests\Mock\AlwaysFilterWPQuery;
  */
 class FilterWPQueryTest extends IntegrationTestCase
 {
-
 	/**
 	 * Test adding the filter
 	 *
@@ -47,7 +45,6 @@ class FilterWPQueryTest extends IntegrationTestCase
 		$this->assertFalse(has_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery']));
 	}
 
-
 	/**
 	 * Test that by default this class does not do anything by default
 	 *
@@ -70,7 +67,6 @@ class FilterWPQueryTest extends IntegrationTestCase
 		$this->assertEquals($postId, $query->posts[0]->ID);
 		$this->assertEquals($postTitle, $query->posts[0]->post_title);
 	}
-
 
 	/**
 	 * Test that the getPosts method return an array
@@ -105,7 +101,6 @@ class FilterWPQueryTest extends IntegrationTestCase
 		//Make sure loop ran
 		$this->assertTrue($looped);
 	}
-
 
 	/**
 	 * Test that the getPosts method does filter when it is explicitly set to so.

--- a/Tests/Integration/RestRequestTest.php
+++ b/Tests/Integration/RestRequestTest.php
@@ -20,7 +20,7 @@ class RestRequestTest extends RestAPITestCase
 		$request = new \WP_REST_Request('GET', '/wp/v2/posts');
 		rest_api_loaded();
 		//Make sure the method returns true
-		$this->assertTrue(FilterWPQuery::shouldFilter());
+		$this->assertTrue(FilterWPQuery::shouldFilter(null));
 	}
 
 
@@ -34,7 +34,7 @@ class RestRequestTest extends RestAPITestCase
 	{
 		//Setup filter
 		AlwaysFilterWPQuery::addFilter();
-		$this->assertTrue(AlwaysFilterWPQuery::shouldFilter());
+		$this->assertTrue(AlwaysFilterWPQuery::shouldFilter(null));
 
 		//Create a request
 		$request = new \WP_REST_Request('GET', '/wp/v2/posts');

--- a/Tests/Integration/RestRequestTest.php
+++ b/Tests/Integration/RestRequestTest.php
@@ -12,7 +12,7 @@ class RestRequestTest extends RestAPITestCase
 	/**
 	 * Ensures that REST API requests will be filtered
 	 *
-	 * @covers FilterWPQuery::callback()
+	 * @covers FilterWPQuery::filterPreQuery()
 	 */
 	public function testShouldFilter()
 	{
@@ -28,7 +28,7 @@ class RestRequestTest extends RestAPITestCase
 	 * Ensure that REST API response data was correctly altered
 	 *
 	 * @covers FilterWPQuery::shouldFilter();
-	 * @covers FilterWPQuery::callback()
+	 * @covers FilterWPQuery::filterPreQuery()
 	 */
 	public function testFilteringRESTRequest()
 	{

--- a/Tests/Mock/AlwaysFilterWPQuery.php
+++ b/Tests/Mock/AlwaysFilterWPQuery.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace CalderaLearn\RestSearch\Tests\Mock;
 
 class AlwaysFilterWPQuery extends \CalderaLearn\RestSearch\FilterWPQuery
 {
-
 	/** @inheritdoc */
 	public static function shouldFilter($postsOrNull): bool
 	{

--- a/Tests/Mock/AlwaysFilterWPQuery.php
+++ b/Tests/Mock/AlwaysFilterWPQuery.php
@@ -7,9 +7,9 @@ class AlwaysFilterWPQuery extends \CalderaLearn\RestSearch\FilterWPQuery
 {
 
 	/** @inheritdoc */
-	public static function shouldFilter(): bool
+	public static function shouldFilter($postsOrNull): bool
 	{
-		return true;
+		return is_null($postsOrNull);
 	}
 
 	/** @inheritdoc */

--- a/Tests/Mock/FilterWPQuery.php
+++ b/Tests/Mock/FilterWPQuery.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace CalderaLearn\RestSearch\Tests\Mock;
 
 /**
@@ -13,19 +12,19 @@ namespace CalderaLearn\RestSearch\Tests\Mock;
 class FilterWPQuery extends \CalderaLearn\RestSearch\FilterWPQuery
 {
 	/** @inheritdoc */
-	public static function shouldFilter($postsOrNull) :bool
+	public static function shouldFilter($postsOrNull): bool
 	{
 		return is_null($postsOrNull);
 	}
 
 	/** @inheritdoc */
-	public static function removeFilter() : bool
+	public static function removeFilter(): bool
 	{
 		return true;
 	}
 
 	/** @inheritdoc */
-	public static function getPosts() : array
+	public static function getPosts(): array
 	{
 		//Create 4 mock posts with different titles
 		$mockPosts = [];

--- a/Tests/Mock/FilterWPQuery.php
+++ b/Tests/Mock/FilterWPQuery.php
@@ -13,9 +13,9 @@ namespace CalderaLearn\RestSearch\Tests\Mock;
 class FilterWPQuery extends \CalderaLearn\RestSearch\FilterWPQuery
 {
 	/** @inheritdoc */
-	public static function shouldFilter() :bool
+	public static function shouldFilter($postsOrNull) :bool
 	{
-		return true;
+		return is_null($postsOrNull);
 	}
 
 	/** @inheritdoc */

--- a/Tests/Unit/FilterWPQueryTest.php
+++ b/Tests/Unit/FilterWPQueryTest.php
@@ -74,7 +74,7 @@ class FilterWPQueryTest extends TestCase
 	/**
 	 * Test the result data is consistent
 	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::callback()
+	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::filterPreQuery()
 	 */
 	public function testCallbackWithNull()
 	{
@@ -82,7 +82,7 @@ class FilterWPQueryTest extends TestCase
 		$expected = FilterWPQuery::getPosts();
 
 		//Get the results from the callback
-		$results  = FilterWPQuery::callback(null);
+		$results  = FilterWPQuery::filterPreQuery(null);
 
 		//Make sure results are an array
 		$this->assertTrue(is_array($results));
@@ -111,7 +111,7 @@ class FilterWPQueryTest extends TestCase
 	/**
 	 * Test the result data is not changed, when passed an array
 	 *
-	 * * @covers \CalderaLearn\RestSearch\FilterWPQuery::callback()
+	 * * @covers \CalderaLearn\RestSearch\FilterWPQuery::filterPreQuery()
 	 */
 	public function testCallbackWithArray()
 	{
@@ -121,7 +121,7 @@ class FilterWPQueryTest extends TestCase
 		$expected = [ $post ];
 
 		//Get the results from the callback
-		$results  = FilterWPQuery::callback($expected);
+		$results  = FilterWPQuery::filterPreQuery($expected);
 
 		//Make sure results are an array
 		$this->assertTrue(is_array($results));

--- a/Tests/Unit/FilterWPQueryTest.php
+++ b/Tests/Unit/FilterWPQueryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace CalderaLearn\RestSearch\Tests\Unit;
 
 use CalderaLearn\RestSearch\Tests\Mock\FilterWPQuery;
@@ -14,7 +13,6 @@ use CalderaLearn\RestSearch\Tests\Mock\FilterWPQuery;
  */
 class FilterWPQueryTest extends TestCase
 {
-
 	/**
 	 * Test that the filter priority is 10
 	 *

--- a/Tests/Unit/FilterWPQueryTest.php
+++ b/Tests/Unit/FilterWPQueryTest.php
@@ -68,7 +68,7 @@ class FilterWPQueryTest extends TestCase
 	 */
 	public function testShouldFilter()
 	{
-		$this->assertTrue(FilterWPQuery::shouldFilter());
+		$this->assertTrue(FilterWPQuery::shouldFilter(null));
 	}
 
 	/**

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -93,7 +93,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 	{
 		$mockPosts = [];
 		for ($i = 0; $i < $quantity; $i++) {
-			$post = new \WP_Post((new \stdClass()));
+			$post = new \WP_Post( new \stdClass() );
 			$post->post_title = "Mock Post $i";
 			$post->filter = 'raw';
 			$mockPosts[$i] = $post;

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -2,6 +2,9 @@
 
 namespace CalderaLearn\RestSearch;
 
+use stdClass;
+use WP_Post;
+
 /**
  * Class FilterWPQuery
  *
@@ -93,7 +96,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 	{
 		$mockPosts = [];
 		for ($i = 0; $i < $quantity; $i++) {
-			$post = new \WP_Post( new \stdClass() );
+			$post = new WP_Post( new stdClass() );
 			$post->post_title = "Mock Post $i";
 			$post->filter = 'raw';
 			$mockPosts[$i] = $post;

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -11,7 +11,6 @@ namespace CalderaLearn\RestSearch;
  */
 class FilterWPQuery implements FiltersPreWPQuery
 {
-
 	/**
 	 * Priority for filter
 	 *
@@ -40,7 +39,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 	}
 
 	/** @inheritdoc */
-	public static function shouldFilter($postsOrNull) :bool
+	public static function shouldFilter($postsOrNull): bool
 	{
 		if ( ! is_null($postsOrNull)) {
 			return false;
@@ -54,32 +53,31 @@ class FilterWPQuery implements FiltersPreWPQuery
 	 *
 	 * @return bool
 	 */
-	private static function doingREST() : bool
+	private static function doingREST(): bool
 	{
 		return did_action('rest_api_init');
 	}
 
 	/** @inheritdoc */
-	public static function addFilter() : bool
+	public static function addFilter(): bool
 	{
 		return add_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], static::$filterPriority);
 	}
 
 	/** @inheritdoc */
-	public static function removeFilter() : bool
+	public static function removeFilter(): bool
 	{
 		return remove_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], static::$filterPriority);
 	}
 
 	/** @inheritdoc */
-	public static function getFilterPriority() : int
+	public static function getFilterPriority(): int
 	{
 		return static::$filterPriority;
 	}
 
-
 	/** @inheritdoc */
-	public static function getPosts() : array
+	public static function getPosts(): array
 	{
 		//Create 4 mock posts with different titles
 		$mockPosts = [];

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -28,13 +28,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 	 */
 	public static function callback($postsOrNull)
 	{
-		// Bail out if not a WordPress REST Request.
-		if ( ! static::shouldFilter()) {
-			return $postsOrNull;
-		}
-
-		// Bail out if posts were already sent.
-		if ( ! is_null($postsOrNull)) {
+		if ( ! static::shouldFilter($postsOrNull)) {
 			return $postsOrNull;
 		}
 
@@ -45,9 +39,19 @@ class FilterWPQuery implements FiltersPreWPQuery
 	}
 
 	/** @inheritdoc */
-	public static function shouldFilter() :bool
+	public static function shouldFilter($postsOrNull) :bool
 	{
-		return did_action('rest_api_init');
+		// REST request checker.
+		if ( ! did_action('rest_api_init')) {
+			return false;
+		}
+
+		// Null checker.
+		if ( ! is_null($postsOrNull)) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/** @inheritdoc */

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -79,15 +79,26 @@ class FilterWPQuery implements FiltersPreWPQuery
 	/** @inheritdoc */
 	public static function getPosts(): array
 	{
-		//Create 4 mock posts with different titles
+		return static::generatePosts(4);
+	}
+
+	/**
+	 * Generates an array of mocked posts.
+	 *
+	 * @param int $quantity Number of posts to generate.
+	 *
+	 * @return array
+	 */
+	private static function generatePosts($quantity): array
+	{
 		$mockPosts = [];
-		for ($i = 0; $i <= 3; $i++) {
+		for ($i = 0; $i < $quantity; $i++) {
 			$post = new \WP_Post((new \stdClass()));
 			$post->post_title = "Mock Post $i";
 			$post->filter = 'raw';
 			$mockPosts[$i] = $post;
 		}
-		//Return a mock array of mock posts
+
 		return $mockPosts;
 	}
 }

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -97,7 +97,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 		$mockPosts = [];
 		for ($postNumber = 0; $postNumber < $quantity; $postNumber++) {
 			$post             = new WP_Post( new stdClass() );
-			$post->post_title = "Mock Post $postNumber";
+			$post->post_title = "Mock Post {$postNumber}";
 			$post->filter     = 'raw';
 			$mockPosts[]      = $post;
 		}

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -18,15 +18,19 @@ class FilterWPQuery implements FiltersPreWPQuery
 	 * @var int
 	 */
 	protected static $filterPriority = 10;
+
 	/**
-	 * Demonstrates how to use a different way to set the posts that WP_Query returns
+	 * Filters the results of WP_Query objects.
+	 *
+	 * This callback demonstrates how to use a different way to set the posts that WP_Query returns.
 	 *
 	 * @uses "posts_pre_query"
 	 *
 	 * @param $postsOrNull
-	 * @return \WP_Post[]
+	 *
+	 * @return array Returns an array of WP_Post objects.
 	 */
-	public static function callback($postsOrNull)
+	public static function filterPreQuery($postsOrNull)
 	{
 		if ( ! static::shouldFilter($postsOrNull)) {
 			return $postsOrNull;
@@ -58,13 +62,13 @@ class FilterWPQuery implements FiltersPreWPQuery
 	/** @inheritdoc */
 	public static function addFilter() : bool
 	{
-		return add_filter('posts_pre_query', [FilterWPQuery::class, 'callback'], 10);
+		return add_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], 10);
 	}
 
 	/** @inheritdoc */
 	public static function removeFilter() : bool
 	{
-		return remove_filter('posts_pre_query', [FilterWPQuery::class, 'callback'], 10);
+		return remove_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], 10);
 	}
 
 	/** @inheritdoc */

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -32,10 +32,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 			return $postsOrNull;
 		}
 
-		// Get mock data
-		$postsOrNull = static::getPosts();
-
-		return $postsOrNull;
+		return static::getPosts();
 	}
 
 	/** @inheritdoc */

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -99,7 +99,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 			$post             = new WP_Post( new stdClass() );
 			$post->post_title = "Mock Post $i";
 			$post->filter     = 'raw';
-			$mockPosts[ $i ]  = $post;
+			$mockPosts[]      = $post;
 		}
 
 		return $mockPosts;

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -95,9 +95,9 @@ class FilterWPQuery implements FiltersPreWPQuery
 	private static function generatePosts($quantity): array
 	{
 		$mockPosts = [];
-		for ($i = 0; $i < $quantity; $i++) {
+		for ($postNumber = 0; $postNumber < $quantity; $postNumber++) {
 			$post             = new WP_Post( new stdClass() );
-			$post->post_title = "Mock Post $i";
+			$post->post_title = "Mock Post $postNumber";
 			$post->filter     = 'raw';
 			$mockPosts[]      = $post;
 		}

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -62,13 +62,13 @@ class FilterWPQuery implements FiltersPreWPQuery
 	/** @inheritdoc */
 	public static function addFilter() : bool
 	{
-		return add_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], 10);
+		return add_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], static::$filterPriority);
 	}
 
 	/** @inheritdoc */
 	public static function removeFilter() : bool
 	{
-		return remove_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], 10);
+		return remove_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'], static::$filterPriority);
 	}
 
 	/** @inheritdoc */

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -96,10 +96,10 @@ class FilterWPQuery implements FiltersPreWPQuery
 	{
 		$mockPosts = [];
 		for ($i = 0; $i < $quantity; $i++) {
-			$post = new WP_Post( new stdClass() );
+			$post             = new WP_Post( new stdClass() );
 			$post->post_title = "Mock Post $i";
-			$post->filter = 'raw';
-			$mockPosts[$i] = $post;
+			$post->filter     = 'raw';
+			$mockPosts[ $i ]  = $post;
 		}
 
 		return $mockPosts;

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -45,11 +45,7 @@ class FilterWPQuery implements FiltersPreWPQuery
 			return false;
 		}
 
-		if ( ! static::doingREST()) {
-			return false;
-		}
-
-		return true;
+		return static::doingREST();
 	}
 
 	/**

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -41,13 +41,13 @@ class FilterWPQuery implements FiltersPreWPQuery
 	/** @inheritdoc */
 	public static function shouldFilter($postsOrNull) :bool
 	{
-		// REST request checker.
-		if ( ! did_action('rest_api_init')) {
+		// Null checker.
+		if ( ! is_null($postsOrNull)) {
 			return false;
 		}
 
-		// Null checker.
-		if ( ! is_null($postsOrNull)) {
+		// REST request checker.
+		if ( ! did_action('rest_api_init')) {
 			return false;
 		}
 

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -28,16 +28,19 @@ class FilterWPQuery implements FiltersPreWPQuery
 	 */
 	public static function callback($postsOrNull)
 	{
-		//Only run during WordPress API requests
-		if (static::shouldFilter()) {
-			//Prevent recursions
-			//Don't run if posts are already sent
-			if (is_null($postsOrNull)) {
-				//Get mock data
-				$postsOrNull = static::getPosts();
-			}
+		// Bail out if not a WordPress REST Request.
+		if ( ! static::shouldFilter()) {
+			return $postsOrNull;
 		}
-		//Always return something, even if its unchanged
+
+		// Bail out if posts were already sent.
+		if ( ! is_null($postsOrNull)) {
+			return $postsOrNull;
+		}
+
+		// Get mock data
+		$postsOrNull = static::getPosts();
+
 		return $postsOrNull;
 	}
 

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -41,17 +41,25 @@ class FilterWPQuery implements FiltersPreWPQuery
 	/** @inheritdoc */
 	public static function shouldFilter($postsOrNull) :bool
 	{
-		// Null checker.
 		if ( ! is_null($postsOrNull)) {
 			return false;
 		}
 
-		// REST request checker.
-		if ( ! did_action('rest_api_init')) {
+		if ( ! static::doingREST()) {
 			return false;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if WordPress is doing a REST request.
+	 *
+	 * @return bool
+	 */
+	private static function doingREST() : bool
+	{
+		return did_action('rest_api_init');
 	}
 
 	/** @inheritdoc */

--- a/src/FiltersPreWPQuery.php
+++ b/src/FiltersPreWPQuery.php
@@ -23,11 +23,12 @@ interface FiltersPreWPQuery
 	public static function callback($postsOrNull);
 
 	/**
-	 * Should this request be filtered?
+	 * Checks if the request should be filtered or not.
 	 *
+	 * @param array|null $postsOrNull Array of WP_Posts or null.
 	 * @return bool
 	 */
-	public static function shouldFilter() :bool;
+	public static function shouldFilter($postsOrNull) :bool;
 
 	/**
 	 * Remove the filter using this callback

--- a/src/FiltersPreWPQuery.php
+++ b/src/FiltersPreWPQuery.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace CalderaLearn\RestSearch;
 
 /**
@@ -31,33 +30,33 @@ interface FiltersPreWPQuery
 	 * @param array|null $postsOrNull Array of WP_Posts or null.
 	 * @return bool
 	 */
-	public static function shouldFilter($postsOrNull) :bool;
+	public static function shouldFilter($postsOrNull): bool;
 
 	/**
 	 * Remove the filter using this callback
 	 *
 	 * @return bool
 	 */
-	public static function removeFilter() :bool;
+	public static function removeFilter(): bool;
 
 	/**
 	 * Add the filter, using this callback
 	 *
 	 * @return bool
 	 */
-	public static function addFilter() : bool;
+	public static function addFilter(): bool;
 
 	/**
 	 * Get the priority for the filter
 	 *
 	 * @return int
 	 */
-	public static function getFilterPriority() : int;
+	public static function getFilterPriority(): int;
 
 	/**
 	 * Create the array of posts to return
 	 *
 	 * @return \WP_Post[]
 	 */
-	public static function getPosts() :array;
+	public static function getPosts(): array;
 }

--- a/src/FiltersPreWPQuery.php
+++ b/src/FiltersPreWPQuery.php
@@ -13,14 +13,17 @@ namespace CalderaLearn\RestSearch;
 interface FiltersPreWPQuery
 {
 	/**
-	 * Change the results of WP_Query objects
+	 * Filters the results of WP_Query objects.
+	 *
+	 * This callback demonstrates how to use a different way to set the posts that WP_Query returns.
 	 *
 	 * @uses "posts_pre_query"
 	 *
 	 * @param $postsOrNull
-	 * @return \WP_Post[]
+	 *
+	 * @return array Returns an array of WP_Post objects.
 	 */
-	public static function callback($postsOrNull);
+	public static function filterPreQuery($postsOrNull);
 
 	/**
 	 * Checks if the request should be filtered or not.


### PR DESCRIPTION
This pull request improves the `FilterWPQuery::getPosts()` method.  It's built off of PR #3.  Therefore, the commits for this PR begin at commit fa841c6.

Improvements include:

- Separating the posts generation as a separate implementation, albeit a separate method at this point.
- Improving its readability via formatting and code style.
- Improving its performance by:
     - Removing the unnecessary array indexer
     - Defining the embedded variable within the string

This PR is [Part 3](https://torquemag.io/2018/05/code-review-part-3-building-refactoring-the-posts-generator/) of my code review series on Torque.