### PR TITLE
Making FilterWPQuery Reusable, Swappable, & Flexible

### DIFF
--- a/Tests/Integration/FilterWPQueryTest.php
+++ b/Tests/Integration/FilterWPQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace CalderaLearn\RestSearch\Tests\Integration;
 
+use CalderaLearn\RestSearch\ContentGetter\PostsGenerator;
 use CalderaLearn\RestSearch\FilterWPQuery;
 use CalderaLearn\RestSearch\Tests\Mock\AlwaysFilterWPQuery;
 
@@ -14,106 +15,106 @@ use CalderaLearn\RestSearch\Tests\Mock\AlwaysFilterWPQuery;
  */
 class FilterWPQueryTest extends IntegrationTestCase
 {
-	/**
-	 * Test adding the filter
-	 *
-	 * @covers FilterWPQuery::addFilter()
-	 */
-	public function testAddFilter()
-	{
-		//Add filter
-		$this->assertTrue(FilterWPQuery::addFilter());
-		//Make sure addFilter() had the right effect --  it was added with priority 10
-		$this->assertEquals(
-			FilterWPQuery::getFilterPriority(),
-			has_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'])
-		);
-	}
+    /**
+     * Test adding the filter
+     *
+     * @covers FilterWPQuery::addFilter()
+     */
+    public function testAddFilter()
+    {
+        //Add filter
+        $this->assertTrue(FilterWPQuery::addFilter());
+        //Make sure addFilter() had the right effect --  it was added with priority 10
+        $this->assertEquals(
+            FilterWPQuery::getFilterPriority(),
+            has_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery'])
+        );
+    }
 
-	/**
-	 * Test removing the filter
-	 *
-	 * @covers FilterWPQuery::shouldFilter()
-	 */
-	public function testFilterRemoved()
-	{
-		//Add filter
-		FilterWPQuery::addFilter();
-		//Remove and test return type
-		$this->assertTrue(FilterWPQuery::removeFilter());
-		//Make sure removeFilter() had the right effect -- the filter was removed
-		$this->assertFalse(has_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery']));
-	}
+    /**
+     * Test removing the filter
+     *
+     * @covers FilterWPQuery::shouldFilter()
+     */
+    public function testFilterRemoved()
+    {
+        //Add filter
+        FilterWPQuery::addFilter();
+        //Remove and test return type
+        $this->assertTrue(FilterWPQuery::removeFilter());
+        //Make sure removeFilter() had the right effect -- the filter was removed
+        $this->assertFalse(has_filter('posts_pre_query', [FilterWPQuery::class, 'filterPreQuery']));
+    }
 
-	/**
-	 * Test that by default this class does not do anything by default
-	 *
-	 * @covers FilterWPQuery::shouldFilter()
-	 * @covers FilterWPQuery::filterPreQuery()
-	 */
-	public function testNotFilteringByDefault()
-	{
-		//Add one post and save its title and ID in variables for comparing to
-		$postTitle = 'The expected post title';
-		$postId = $this->factory->post->create(['post_title' => $postTitle]);
-		//Add filter
-		FilterWPQuery::addFilter();
-		//Test that the filter SHOULD not do anything
-		$this->assertFalse(FilterWPQuery::shouldFilter([]));
-		//Query for all posts -- should only be one post, the one we just created.
-		$query = new \WP_Query(['post_type' => 'post']);
-		$this->assertFalse(empty($query->posts));
-		$this->assertEquals(1, count($query->posts[0]));
-		$this->assertEquals($postId, $query->posts[0]->ID);
-		$this->assertEquals($postTitle, $query->posts[0]->post_title);
-	}
+    /**
+     * Test that by default this class does not do anything by default
+     *
+     * @covers FilterWPQuery::shouldFilter()
+     * @covers FilterWPQuery::filterPreQuery()
+     */
+    public function testNotFilteringByDefault()
+    {
+        //Add one post and save its title and ID in variables for comparing to
+        $postTitle = 'The expected post title';
+        $postId    = $this->factory->post->create(['post_title' => $postTitle]);
+        //Add filter
+        FilterWPQuery::addFilter();
+        //Test that the filter SHOULD not do anything
+        $this->assertFalse(FilterWPQuery::shouldFilter([]));
+        //Query for all posts -- should only be one post, the one we just created.
+        $query = new \WP_Query(['post_type' => 'post']);
+        $this->assertFalse(empty($query->posts));
+        $this->assertEquals(1, count($query->posts[0]));
+        $this->assertEquals($postId, $query->posts[0]->ID);
+        $this->assertEquals($postTitle, $query->posts[0]->post_title);
+    }
 
-	/**
-	 * Test that the getPosts method return an array
-	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
-	 */
-	public function testGetPosts()
-	{
-		//Get the mock posts
-		$results = FilterWPQuery::getPosts();
-		//Make sure results are an array
-		$this->assertTrue(is_array($results));
-	}
+    /**
+     * Test that the getPosts method return an array
+     *
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
+     */
+    public function testGetPosts()
+    {
+        //Get the mock posts
+        $results = FilterWPQuery::getPosts();
+        //Make sure results are an array
+        $this->assertTrue(is_array($results));
+    }
 
-	/**
-	 * Test that the getPosts method returns an array of WP_Posts.
-	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
-	 */
-	public function testGetPostsArePosts()
-	{
-		//Get the mock posts
-		$results = FilterWPQuery::getPosts();
-		$this->assertFalse(empty($results));
-		//Make sure results are an array of WP_Posts
-		$looped = false;
-		foreach ($results as $result) {
-			$looped = true;
-			//Make sure all results are WP_Posts
-			$this->assertTrue(is_a($result, '\WP_Post'), get_class($result));
-		}
-		//Make sure loop ran
-		$this->assertTrue($looped);
-	}
+    /**
+     * Test that the getPosts method returns an array of WP_Posts.
+     *
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
+     */
+    public function testGetPostsArePosts()
+    {
+        //Get the mock posts
+        $results = FilterWPQuery::getPosts();
+        $this->assertFalse(empty($results));
+        //Make sure results are an array of WP_Posts
+        $looped = false;
+        foreach ($results as $result) {
+            $looped = true;
+            //Make sure all results are WP_Posts
+            $this->assertTrue(is_a($result, '\WP_Post'), get_class($result));
+        }
+        //Make sure loop ran
+        $this->assertTrue($looped);
+    }
 
-	/**
-	 * Test that the getPosts method does filter when it is explicitly set to so.
-	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
-	 */
-	public function testGetPostsArePostsShouldFilter()
-	{
-		//Get the mock posts
-		$results = AlwaysFilterWPQuery::filterPreQuery(null);
-		$this->assertTrue(is_array($results));
-		$this->assertFalse(empty($results));
-		$expected = AlwaysFilterWPQuery::getPosts();
-		$this->assertEquals(count($expected), count($results));
-	}
+    /**
+     * Test that the getPosts method does filter when it is explicitly set to so.
+     *
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
+     */
+    public function testGetPostsArePostsShouldFilter()
+    {
+        //Get the mock posts
+        $results = AlwaysFilterWPQuery::filterPreQuery(null);
+        $this->assertTrue(is_array($results));
+        $this->assertFalse(empty($results));
+        $expected = AlwaysFilterWPQuery::getPosts();
+        $this->assertEquals(count($expected), count($results));
+    }
 }

--- a/Tests/Integration/FilterWPQueryTest.php
+++ b/Tests/Integration/FilterWPQueryTest.php
@@ -76,8 +76,12 @@ class FilterWPQueryTest extends IntegrationTestCase
      */
     public function testGetPosts()
     {
+        // Initialize by loading the implementation.
+        FilterWPQuery::init(new PostsGenerator());
+
         //Get the mock posts
         $results = FilterWPQuery::getPosts();
+
         //Make sure results are an array
         $this->assertTrue(is_array($results));
     }
@@ -89,9 +93,14 @@ class FilterWPQueryTest extends IntegrationTestCase
      */
     public function testGetPostsArePosts()
     {
+        // Initialize by loading the implementation.
+        FilterWPQuery::init(new PostsGenerator());
+
         //Get the mock posts
         $results = FilterWPQuery::getPosts();
+
         $this->assertFalse(empty($results));
+
         //Make sure results are an array of WP_Posts
         $looped = false;
         foreach ($results as $result) {

--- a/Tests/Integration/IntegrationTestCase.php
+++ b/Tests/Integration/IntegrationTestCase.php
@@ -1,7 +1,8 @@
 <?php
 
-
 namespace CalderaLearn\RestSearch\Tests\Integration;
+
+use Mockery;
 
 /**
  * Class IntegrationTestCase
@@ -12,6 +13,12 @@ namespace CalderaLearn\RestSearch\Tests\Integration;
  */
 abstract class IntegrationTestCase extends \WP_UnitTestCase
 {
-
-
+	/**
+	 * Cleans up the test environment after each test.
+	 */
+	public function tearDown()
+	{
+		Mockery::close();
+		parent::tearDown();
+	}
 }

--- a/Tests/Unit/FilterWPQueryTest.php
+++ b/Tests/Unit/FilterWPQueryTest.php
@@ -2,146 +2,212 @@
 
 namespace CalderaLearn\RestSearch\Tests\Unit;
 
-use CalderaLearn\RestSearch\Tests\Mock\FilterWPQuery;
+use Brain\Monkey;
+use CalderaLearn\RestSearch\FilterWPQuery;
+use CalderaLearn\RestSearch\ContentGetter\ContentGetterContract;
+use Mockery;
 
 /**
  * Class FilterWPQueryTest
  *
- * Unit tests for class that modifies WP_Queryt
+ * Unit tests for class that modifies WP_Query
  *
  * @package CalderaLearn\RestSearch\Tests\Unit
  */
 class FilterWPQueryTest extends TestCase
 {
-	/**
-	 * Test that the filter priority is 10
-	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::getFilterPriority()
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::$filterPriority
-	 */
-	public function testGetPriority()
-	{
-		$this->assertEquals(10, FilterWPQuery::getFilterPriority());
-	}
+    /**
+     * Array of mocked posts.
+     *
+     * @var array
+     */
+    protected $mockedPosts;
 
-	/**
-	 * Test that the getPosts method return an array
-	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
-	 */
-	public function testGetPosts()
-	{
-		//Get the mock posts
-		$results = FilterWPQuery::getPosts();
-		//Make sure results are an array
-		$this->assertTrue(is_array($results));
-	}
+    /**
+     * Prepares the test environment before each test.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockedPosts = [];
+    }
 
-	/**
-	 * Test that the getPosts method return of WP_Posts
-	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
-	 */
-	public function testGetPostsArePosts()
-	{
-		//Get the mock posts
-		$results = FilterWPQuery::getPosts();
-		$this->assertFalse(empty($results));
-		//Make sure results are an array of WP_Posts
-		$looped = false;
-		foreach ($results as $result) {
-			$looped = true;
-			//Make sure all results are WP_Posts
-			$this->assertTrue(is_a($result, '\WP_Post'), get_class($result));
-		}
-		//Make sure loop ran
-		$this->assertTrue($looped);
-	}
+    /**
+     * Test that the filter priority is 10
+     *
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::getFilterPriority()
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::$filterPriority
+     */
+    public function testGetPriority()
+    {
+        $this->assertEquals(10, FilterWPQuery::getFilterPriority());
+    }
 
-	/**
-	 * Test that our mock returns true for should filter
-	 *
-	 * @covers FilterWPQuery::shouldFilter()
-	 * @covers FilterWPQueryTest::testWithNull()
-	 */
-	public function testShouldFilter()
-	{
-		$this->assertTrue(FilterWPQuery::shouldFilter(null));
-	}
+    /**
+     * Test that the getPosts method return an array
+     *
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
+     */
+    public function testGetPosts()
+    {
+        // Set up the Content Getter mock.
+        $postsGeneratorMock = Mockery::mock(ContentGetterContract::class);
+        $postsGeneratorMock->shouldReceive('getContent')->andReturn([]);
+        FilterWPQuery::init($postsGeneratorMock);
 
-	/**
-	 * Test the result data is consistent
-	 *
-	 * @covers \CalderaLearn\RestSearch\FilterWPQuery::filterPreQuery()
-	 */
-	public function testCallbackWithNull()
-	{
-		//Use the mock data we have in our mock class as the expected values
-		$expected = FilterWPQuery::getPosts();
+        //Get the mock posts
+        $results = FilterWPQuery::getPosts();
+        //Make sure results are an array
+        $this->assertTrue(is_array($results));
+    }
 
-		//Get the results from the callback
-		$results  = FilterWPQuery::filterPreQuery(null);
+    /**
+     * Test that the getPosts method return of WP_Posts
+     *
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::getPosts()
+     */
+    public function testGetPostsArePosts()
+    {
+        // Set up the mocks.
+        $postsGeneratorMock = Mockery::mock(ContentGetterContract::class);
+        FilterWPQuery::init($postsGeneratorMock);
+        $postsGeneratorMock->shouldReceive('getContent')
+            ->once()
+            ->andReturnUsing([$this, 'generateMockedPosts']);
 
-		//Make sure results are an array
-		$this->assertTrue(is_array($results));
+        //Get the mock posts
+        $results = FilterWPQuery::getPosts();
+        $this->assertFalse(empty($results));
+        //Make sure results are an array of WP_Posts
+        $looped = false;
+        foreach ($results as $result) {
+            $looped = true;
+            //Make sure all results are WP_Posts
+            $this->assertTrue(is_a($result, '\WP_Post'), get_class($result));
+        }
+        //Make sure loop ran
+        $this->assertTrue($looped);
+    }
 
-		//Make sure the two arrays are the same size
-		$this->assertCount(count($expected), $results);
+    /**
+     * Test that our mock returns true for should filter
+     *
+     * @covers FilterWPQuery::shouldFilter()
+     * @covers FilterWPQueryTest::testWithNull()
+     */
+    public function testShouldFilter()
+    {
+        Monkey\Functions\expect('did_action')
+            ->once()
+            ->with('rest_api_init')
+            ->andReturn(1);
+        $this->assertTrue(FilterWPQuery::shouldFilter(null));
+    }
 
-		/** These arrays are not the same, compare the meaning of the contents */
+    /**
+     * Test the result data is consistent
+     *
+     * @covers \CalderaLearn\RestSearch\FilterWPQuery::filterPreQuery()
+     */
+    public function testCallbackWithNull()
+    {
+        // Set up the mocks.
+        Monkey\Functions\expect('did_action')
+            ->once()
+            ->with('rest_api_init')
+            ->andReturn(1);
+        $postsGeneratorMock = Mockery::mock(ContentGetterContract::class);
+        FilterWPQuery::init($postsGeneratorMock);
+        $postsGeneratorMock->shouldReceive('getContent')
+            ->once()
+            ->andReturnUsing([$this, 'generateMockedPosts']);
 
-		//Used to make sure this loop of tests ran
-		$looped = false;
-		/**
-		 * Loop through expected, comparing to eactual results
-		 * @var int $i
-		 * @var  \WP_Post $post
-		 */
-		foreach ($expected as $i => $post) {
-			$looped = true;
-			//Test that the mock and resulting post titles are the same
-			$this->assertSame($post->post_title, $results[$i]->post_title);
-		}
-		//Make sure loop ran
-		$this->assertTrue($looped);
-	}
+        //Get the results from the callback
+        $results = FilterWPQuery::filterPreQuery(null);
 
-	/**
-	 * Test the result data is not changed, when passed an array
-	 *
-	 * * @covers \CalderaLearn\RestSearch\FilterWPQuery::filterPreQuery()
-	 */
-	public function testCallbackWithArray()
-	{
-		//Create 1 mock posts
-		$post = new \WP_Post((new \stdClass()));
-		$post->post_title = 'The title of this post is post';
-		$expected = [ $post ];
+        //Make sure results are an array
+        $this->assertTrue(is_array($results));
 
-		//Get the results from the callback
-		$results  = FilterWPQuery::filterPreQuery($expected);
+        //Make sure the two arrays are the same size
+        $this->assertCount(count($this->mockedPosts), $results);
 
-		//Make sure results are an array
-		$this->assertTrue(is_array($results));
+        /** These arrays are not the same, compare the meaning of the contents */
 
-		//Make sure the two arrays are the same size
-		$this->assertCount(count($expected), $results);
+        //Used to make sure this loop of tests ran
+        $looped = false;
+        /**
+         * Loop through expected, comparing to actual results
+         * @var int $i
+         * @var  \WP_Post $post
+         */
+        foreach ($this->mockedPosts as $index => $post) {
+            $looped = true;
+            //Test that the mock and resulting post titles are the same
+            $this->assertSame($post->post_title, $results[$index]->post_title);
+        }
+        //Make sure loop ran
+        $this->assertTrue($looped);
+    }
 
-		/** These arrays are not the same, compare the meaning of the contents */
+    /**
+     * Test the result data is not changed, when passed an array
+     *
+     * * @covers \CalderaLearn\RestSearch\FilterWPQuery::filterPreQuery()
+     */
+    public function testCallbackWithArray()
+    {
+        // Set up the mocks.
+        Monkey\Functions\expect('did_action')->with('rest_api_init')->never();
+        $postsGeneratorMock = Mockery::mock(ContentGetterContract::class);
+        FilterWPQuery::init($postsGeneratorMock);
+        $postsGeneratorMock->shouldNotReceive('getContent');
 
-		//Used to make sure this loop of tests ran
-		$looped = false;
-		/**
-		 * Loop through expected, comparing to eactual results
-		 * @var int $i
-		 * @var  \WP_Post $post
-		 */
-		foreach ($expected as $i => $post) {
-			$looped = true;
-			//Test that the mock and resulting post titles are the same
-			$this->assertSame($post->post_title, $results[$i]->post_title);
-		}
-		//Make sure loop ran
-		$this->assertTrue($looped);
-	}
+        //Create 1 mock posts
+        $expected = $this->generateMockedPosts(1);
+
+        //Get the results from the callback
+        $results = FilterWPQuery::filterPreQuery($expected);
+
+        //Make sure results are an array
+        $this->assertTrue(is_array($results));
+
+        //Make sure the two arrays are the same size
+        $this->assertCount(count($expected), $results);
+
+        /** These arrays are not the same, compare the meaning of the contents */
+
+        //Used to make sure this loop of tests ran
+        $looped = false;
+        /**
+         * Loop through expected, comparing to eactual results
+         * @var int $i
+         * @var  \WP_Post $post
+         */
+        foreach ($expected as $index => $post) {
+            $looped = true;
+            //Test that the mock and resulting post titles are the same
+            $this->assertSame($post->post_title, $results[$index]->post_title);
+        }
+        //Make sure loop ran
+        $this->assertTrue($looped);
+    }
+
+    /**
+     * Generates mocked posts for our tests.
+     *
+     * @param int $quantity Number of mocked posts to generate.
+     *
+     * @return array
+     */
+    public function generateMockedPosts($quantity = 4): array
+    {
+        $this->mockedPosts = [];
+        for ($postNumber = 0; $postNumber < $quantity; $postNumber++) {
+            $post                = Mockery::mock('WP_Post');
+            $post->post_title    = "Mock Post {$postNumber}";
+            $post->filter        = 'raw';
+            $this->mockedPosts[] = $post;
+        }
+        return $this->mockedPosts;
+    }
 }

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-
 namespace CalderaLearn\RestSearch\Tests\Unit;
 
+use Brain\Monkey;
 //Import PHP unit test case.
 //Must be aliased to avoid having two classes of same name in scope.
 use PHPUnit\Framework\TestCase as FrameworkTestCase;
@@ -15,5 +15,20 @@ use PHPUnit\Framework\TestCase as FrameworkTestCase;
  */
 abstract class TestCase extends FrameworkTestCase
 {
-	//We'll put shared code for all tests here later
+    /**
+     * Prepares the test environment before each test.
+     */
+    protected function setUp() {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    /**
+     * Cleans up the test environment after each test.
+     */
+    protected function tearDown()
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,9 @@
     },
     "require-dev": {
         "php": "^7.1",
-        "phpunit/phpunit": "^7.0",
+        "brain/monkey": "^2.2",
         "mockery/mockery": ">=0.9 <2",
+        "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.2",
         "jakub-onderka/php-parallel-lint": "^1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "require-dev": {
         "php": "^7.1",
         "phpunit/phpunit": "^7.0",
+        "mockery/mockery": ">=0.9 <2",
         "squizlabs/php_codesniffer": "^3.2",
         "jakub-onderka/php-parallel-lint": "^1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -32,14 +32,13 @@
     "autoload-dev": {
         "psr-4": {
             "CalderaLearn\\RestSearch\\Tests\\": "Tests/"
-        },
-        "files": ["Tests/Mock/WP_Post.php"]
+        }
     },
     "require-dev": {
         "php": "^7.1",
         "brain/monkey": "^2.2",
         "mockery/mockery": ">=0.9 <2",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "~5.7.9",
         "squizlabs/php_codesniffer": "^3.2",
         "jakub-onderka/php-parallel-lint": "^1.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,92 +4,10 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e3f5a001ec0abea81d46d91f6aefa11",
+    "hash": "c38f11c5e3ebc3b685aa84c64258e403",
+    "content-hash": "02e16654cd7dd88d0459a02b99607b08",
     "packages": [],
     "packages-dev": [
-        {
-            "name": "atoum/atoum",
-            "version": "3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/atoum/atoum.git",
-                "reference": "c5279d0ecd4e2d53af6b38815db2cafee8fc46b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/atoum/atoum/zipball/c5279d0ecd4e2d53af6b38815db2cafee8fc46b6",
-                "reference": "c5279d0ecd4e2d53af6b38815db2cafee8fc46b6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-hash": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "ext-xml": "*",
-                "php": "^5.6.0 || ^7.0.0 <7.4.0"
-            },
-            "replace": {
-                "mageekguy/atoum": "*"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2"
-            },
-            "suggest": {
-                "atoum/stubs": "Provides IDE support (like autocompletion) for atoum",
-                "ext-mbstring": "Provides support for UTF-8 strings",
-                "ext-xdebug": "Provides code coverage report (>= 2.3)"
-            },
-            "bin": [
-                "bin/atoum"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "classes/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Frédéric Hardy",
-                    "email": "frederic.hardy@atoum.org",
-                    "homepage": "http://blog.mageekbox.net"
-                },
-                {
-                    "name": "François Dussert",
-                    "email": "francois.dussert@atoum.org"
-                },
-                {
-                    "name": "Gérald Croes",
-                    "email": "gerald.croes@atoum.org"
-                },
-                {
-                    "name": "Julien Bianchi",
-                    "email": "julien.bianchi@atoum.org"
-                },
-                {
-                    "name": "Ludovic Fleury",
-                    "email": "ludovic.fleury@atoum.org"
-                }
-            ],
-            "description": "Simple modern and intuitive unit testing framework for PHP 5.3+",
-            "homepage": "http://www.atoum.org",
-            "keywords": [
-                "TDD",
-                "atoum",
-                "test",
-                "unit testing"
-            ],
-            "time": "2018-03-15T22:46:39+00:00"
-        },
         {
             "name": "doctrine/instantiator",
             "version": "1.1.0",
@@ -142,7 +60,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2017-07-22 11:58:36"
         },
         {
             "name": "jakub-onderka/php-parallel-lint",
@@ -190,7 +108,7 @@
             ],
             "description": "This tool check syntax of PHP files about 20x faster than serial check.",
             "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-            "time": "2018-02-24T15:31:20+00:00"
+            "time": "2018-02-24 15:31:20"
         },
         {
             "name": "myclabs/deep-copy",
@@ -235,7 +153,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2017-10-19 19:58:43"
         },
         {
             "name": "phar-io/manifest",
@@ -290,7 +208,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2017-03-05 18:14:27"
         },
         {
             "name": "phar-io/version",
@@ -337,7 +255,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2017-03-05 17:38:23"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -391,7 +309,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2017-09-11 18:02:19"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -442,7 +360,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2017-11-30 07:14:17"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -489,27 +407,27 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "time": "2017-07-14 14:27:02"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
@@ -552,20 +470,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2018-04-18 13:57:24"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
+                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
-                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/774a82c0c5da4c1c7701790c262035d235ab7856",
+                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856",
                 "shasum": ""
             },
             "require": {
@@ -576,7 +494,7 @@
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
+                "sebastian/environment": "^3.1",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
@@ -615,7 +533,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-02T07:01:41+00:00"
+            "time": "2018-04-06 15:39:20"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -662,7 +580,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2017-11-27 13:52:08"
         },
         {
             "name": "phpunit/php-text-template",
@@ -703,7 +621,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -752,7 +670,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-02-01T13:07:23+00:00"
+            "time": "2018-02-01 13:07:23"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -801,20 +719,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-02-01T13:16:43+00:00"
+            "time": "2018-02-01 13:16:43"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.0.3",
+            "version": "7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e"
+                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/536f4d853c12d8189963435088e8ff7c0daeab2e",
-                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6d51299e307dc510149e0b7cd1931dd11770e1cb",
+                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb",
                 "shasum": ""
             },
             "require": {
@@ -832,8 +750,8 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.0",
-                "sebastian/comparator": "^2.1",
+                "phpunit/phpunit-mock-objects": "^6.1.1",
+                "sebastian/comparator": "^2.1 || ^3.0",
                 "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
@@ -855,7 +773,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-master": "7.1-dev"
                 }
             },
             "autoload": {
@@ -881,20 +799,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-03-26T07:36:48+00:00"
+            "time": "2018-04-18 13:41:53"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "6.0.1",
+            "version": "6.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
+                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
-                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/70c740bde8fd9ea9ea295be1cd875dd7b267e157",
+                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157",
                 "shasum": ""
             },
             "require": {
@@ -912,7 +830,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -937,7 +855,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-02-15T05:27:38+00:00"
+            "time": "2018-04-11 04:50:36"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -982,34 +900,34 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "time": "2017-03-04 06:30:41"
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
+                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1046,7 +964,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-04-18 13:33:00"
         },
         {
             "name": "sebastian/diff",
@@ -1102,7 +1020,7 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2018-02-01T13:45:15+00:00"
+            "time": "2018-02-01 13:45:15"
         },
         {
             "name": "sebastian/environment",
@@ -1152,7 +1070,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2017-07-01 08:51:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1219,7 +1137,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2017-04-03 13:19:02"
         },
         {
             "name": "sebastian/global-state",
@@ -1270,7 +1188,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2017-04-27 15:39:26"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1317,7 +1235,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "time": "2017-08-03 12:35:26"
         },
         {
             "name": "sebastian/object-reflector",
@@ -1362,7 +1280,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "time": "2017-03-29 09:07:27"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1415,7 +1333,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "time": "2017-03-03 06:23:57"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1457,7 +1375,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2015-07-28 20:34:47"
         },
         {
             "name": "sebastian/version",
@@ -1500,7 +1418,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1551,7 +1469,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
+            "time": "2018-02-20 21:35:23"
         },
         {
             "name": "theseer/tokenizer",
@@ -1591,7 +1509,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2017-04-07 12:08:54"
         },
         {
             "name": "webmozart/assert",
@@ -1641,7 +1559,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-01-29 19:49:41"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1,13 +1,117 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "c38f11c5e3ebc3b685aa84c64258e403",
-    "content-hash": "02e16654cd7dd88d0459a02b99607b08",
+    "content-hash": "08846f768bda56d42489f8ddbd7db768",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "3bb81ace3914c220aa273d1c0603d5e1b454c0d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/3bb81ace3914c220aa273d1c0603d5e1b454c0d7",
+                "reference": "3bb81ace3914c220aa273d1c0603d5e1b454c0d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "http://patchwork2.org/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "time": "2018-02-19T18:52:50+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "ed9e0698bc1292f33698719da8ca1aa2e18acc51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/ed9e0698bc1292f33698719da8ca1aa2e18acc51",
+                "reference": "ed9e0698bc1292f33698719da8ca1aa2e18acc51",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.0",
+                "mockery/mockery": ">=0.9 <2",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-version/1": "1.x-dev",
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                },
+                "files": [
+                    "inc/api.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "time": "2017-12-01T16:32:09+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.1.0",
@@ -60,7 +164,55 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22 11:58:36"
+            "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2016-01-20T08:20:44+00:00"
         },
         {
             "name": "jakub-onderka/php-parallel-lint",
@@ -108,7 +260,73 @@
             ],
             "description": "This tool check syntax of PHP files about 20x faster than serial check.",
             "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-            "time": "2018-02-24 15:31:20"
+            "time": "2018-02-24T15:31:20+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/99e29d3596b16dabe4982548527d5ddf90232e99",
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~2.0",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpdocumentor/phpdocumentor": "^2.9",
+                "phpunit/phpunit": "~5.7.10|~6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2018-05-08T08:54:48+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -153,109 +371,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19 19:58:43"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05 18:14:27"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "time": "2017-03-05 17:38:23"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -309,7 +425,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -360,7 +476,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30 07:14:17"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -407,7 +523,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14 14:27:02"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -470,44 +586,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18 13:57:24"
+            "time": "2018-04-18T13:57:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.3",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/774a82c0c5da4c1c7701790c262035d235ab7856",
-                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -522,7 +638,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -533,7 +649,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06 15:39:20"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -580,7 +696,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27 13:52:08"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -621,32 +737,32 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.0.0",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -661,7 +777,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -670,33 +786,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-02-01 13:07:23"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -719,20 +835,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-02-01 13:16:43"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.1.4",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6d51299e307dc510149e0b7cd1931dd11770e1cb",
-                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
@@ -741,31 +857,33 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.1",
-                "phpunit/php-file-iterator": "^1.4.3",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.1.1",
-                "sebastian/comparator": "^2.1 || ^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "~1.1"
             },
             "bin": [
                 "phpunit"
@@ -773,7 +891,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.1-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -799,30 +917,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-18 13:41:53"
+            "time": "2018-02-01T05:50:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "6.1.1",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/70c740bde8fd9ea9ea295be1cd875dd7b267e157",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -830,7 +951,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -845,7 +966,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -855,7 +976,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-04-11 04:50:36"
+            "time": "2017-06-30T09:13:00+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -900,34 +1021,34 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04 06:30:41"
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.0",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -958,39 +1079,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2018-04-18 13:33:00"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.0",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1015,37 +1135,34 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
+                "diff"
             ],
-            "time": "2018-02-01 13:45:15"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1070,34 +1187,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01 08:51:00"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1137,27 +1254,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03 13:19:02"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.2"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1165,7 +1282,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1188,34 +1305,33 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27 15:39:26"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1235,77 +1351,32 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03 12:35:26"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29 09:07:27"
+            "time": "2017-02-18T15:18:39+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1333,7 +1404,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03 06:23:57"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1375,7 +1446,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1418,7 +1489,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1469,47 +1540,121 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20 21:35:23"
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
             "autoload": {
-                "classmap": [
-                    "src/"
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07 12:08:54"
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30T19:57:29+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "048b1be5fb96e73ff1d065f5e7e23f84415ac907"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/048b1be5fb96e73ff1d065f5e7e23f84415ac907",
+                "reference": "048b1be5fb96e73ff1d065f5e7e23f84415ac907",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-05-07T07:12:24+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1559,7 +1704,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29 19:49:41"
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],

--- a/rest-api-search.php
+++ b/rest-api-search.php
@@ -18,7 +18,7 @@ include_once __DIR__ .'/vendor/autoload.php';
 /**
  * Load plugin if WordPress is loaded
  */
-if( function_exists( 'init' ) ){
+if( zfunction_exists( 'init' ) ){
     add_action( 'init', function(){
         $hooks = new \CalderaLearn\RestSearch\Hooks();
         $hooks->addHooks();

--- a/rest-api-search.php
+++ b/rest-api-search.php
@@ -12,15 +12,24 @@
  * @package         Rest_Api_Search
  */
 
+namespace CalderaLearn\RestSearch;
+
+use CalderaLearn\RestSearch\ContentGetter\PostsGenerator;
 
 include_once __DIR__ .'/vendor/autoload.php';
 
 /**
- * Load plugin if WordPress is loaded
+ * Load plugin if WordPress is loaded.
  */
-if( zfunction_exists( 'init' ) ){
-    add_action( 'init', function(){
-        $hooks = new \CalderaLearn\RestSearch\Hooks();
-        $hooks->addHooks();
-    });
+if ( ! function_exists( 'init' ) ) {
+	return;
 }
+
+/**
+ * Launch the plugin.
+ */
+add_action( 'init', function(){
+	FilterWPQuery::init( new PostsGenerator() );
+
+	( new Hooks() )->addHooks();
+});

--- a/src/ContentGetter/ContentGetterContract.php
+++ b/src/ContentGetter/ContentGetterContract.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CalderaLearn\RestSearch\ContentGetter;
+
+/**
+ * Defines the contract for each content getter implementation.
+ * @package CalderaLearn\RestSearch\ContentGetter
+ */
+interface ContentGetterContract
+{
+	/**
+	 * Handles getting the content for the search query.
+	 *
+	 * @param int $quantity Number to get.
+	 *
+	 * @return array
+	 */
+	public function getContent( $quantity = 4 ) : array;
+}

--- a/src/ContentGetter/ContentGetterContract.php
+++ b/src/ContentGetter/ContentGetterContract.php
@@ -15,5 +15,5 @@ interface ContentGetterContract
 	 *
 	 * @return array
 	 */
-	public function getContent( $quantity = 4 ) : array;
+	public function getContent( $quantity = 4 ): array;
 }

--- a/src/ContentGetter/PostsGenerator.php
+++ b/src/ContentGetter/PostsGenerator.php
@@ -2,6 +2,9 @@
 
 namespace CalderaLearn\RestSearch\ContentGetter;
 
+use stdClass;
+use WP_Post;
+
 /**
  * Handles generating posts for the search query.
  * @package CalderaLearn\RestSearch\ContentGetter
@@ -27,7 +30,7 @@ class PostsGenerator implements ContentGetterContract
 	 *
 	 * @return array
 	 */
-	private static function generatePosts($quantity): array
+	private function generatePosts($quantity): array
 	{
 		$mockPosts = [];
 		for ($postNumber = 0; $postNumber < $quantity; $postNumber++) {

--- a/src/ContentGetter/PostsGenerator.php
+++ b/src/ContentGetter/PostsGenerator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CalderaLearn\RestSearch\ContentGetter;
+
+/**
+ * Handles generating posts for the search query.
+ * @package CalderaLearn\RestSearch\ContentGetter
+ */
+class PostsGenerator implements ContentGetterContract
+{
+	/**
+	 * Handles getting the content for the search query.
+	 *
+	 * @param int $quantity Number to get.
+	 *
+	 * @return array
+	 */
+	public function getContent($quantity = 4): array
+	{
+		return $this->generatePosts($quantity);
+	}
+
+	/**
+	 * Generates an array of mocked posts.
+	 *
+	 * @param int $quantity Number of posts to generate.
+	 *
+	 * @return array
+	 */
+	private static function generatePosts($quantity): array
+	{
+		$mockPosts = [];
+		for ($postNumber = 0; $postNumber < $quantity; $postNumber++) {
+			$post             = new WP_Post( new stdClass() );
+			$post->post_title = "Mock Post {$postNumber}";
+			$post->filter     = 'raw';
+			$mockPosts[]      = $post;
+		}
+
+		return $mockPosts;
+	}
+}

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -2,6 +2,7 @@
 
 namespace CalderaLearn\RestSearch;
 
+use CalderaLearn\RestSearch\ContentGetter\ContentGetterContract;
 use stdClass;
 use WP_Post;
 
@@ -14,6 +15,13 @@ use WP_Post;
  */
 class FilterWPQuery implements FiltersPreWPQuery
 {
+	/**
+	 * Content Getter Implementation.
+	 *
+	 * @var ContentGetterContract
+	 */
+	protected static $contentGetter;
+
 	/**
 	 * Priority for filter
 	 *
@@ -82,26 +90,6 @@ class FilterWPQuery implements FiltersPreWPQuery
 	/** @inheritdoc */
 	public static function getPosts(): array
 	{
-		return static::generatePosts(4);
-	}
-
-	/**
-	 * Generates an array of mocked posts.
-	 *
-	 * @param int $quantity Number of posts to generate.
-	 *
-	 * @return array
-	 */
-	private static function generatePosts($quantity): array
-	{
-		$mockPosts = [];
-		for ($postNumber = 0; $postNumber < $quantity; $postNumber++) {
-			$post             = new WP_Post( new stdClass() );
-			$post->post_title = "Mock Post {$postNumber}";
-			$post->filter     = 'raw';
-			$mockPosts[]      = $post;
-		}
-
-		return $mockPosts;
+		return static::$contentGetter->getContent(4);
 	}
 }

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -30,6 +30,18 @@ class FilterWPQuery implements FiltersPreWPQuery
 	protected static $filterPriority = 10;
 
 	/**
+	 * Initialize the search filter by binding a specific content getter implementation.
+	 *
+	 * @param ContentGetterContract $contentGetter Instance of the implementation.
+	 *
+	 * @return void
+	 */
+	public static function init(ContentGetterContract $contentGetter)
+	{
+		static::$contentGetter = $contentGetter;
+	}
+
+	/**
 	 * Filters the results of WP_Query objects.
 	 *
 	 * This callback demonstrates how to use a different way to set the posts that WP_Query returns.

--- a/src/FilterWPQuery.php
+++ b/src/FilterWPQuery.php
@@ -3,8 +3,6 @@
 namespace CalderaLearn\RestSearch;
 
 use CalderaLearn\RestSearch\ContentGetter\ContentGetterContract;
-use stdClass;
-use WP_Post;
 
 /**
  * Class FilterWPQuery
@@ -102,6 +100,6 @@ class FilterWPQuery implements FiltersPreWPQuery
 	/** @inheritdoc */
 	public static function getPosts(): array
 	{
-		return static::$contentGetter->getContent(4);
+		return static::$contentGetter->getContent();
 	}
 }


### PR DESCRIPTION
This pull request separates the task of "getting the content" from `FilterWPQuery`.  It makes the class reusable while providing a mechanism to wire up specific project implementations for getting content for the search query.

It's built off of PR #4.  Therefore, the commits for this PR begin at commit d08fac0.

Improvements include:

- Added a repo for content getters
- Added a contract to _strictly define_ how to interface with each implementation
- Moved the posts generator into its own implementation
- Added an `init()` method to `FilterWPQuery` and injected the implementation.
- Modified `getPosts()` to use the generic object and invoke the `getContent` method on whatever implementation is wired to it.

With this change, `FilterWPQuery` does not care which implementation is used.  It provides a clean way to reuse this code from project-to-project.

This PR is [Part 4]() of my article series on Torque Magazine.  